### PR TITLE
Support png transparency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,9 +8,10 @@ Maintainer: mikefc <mikefc@coolbutuseless.com>
 Description: Fast output of numeric matrices and arrays to NETPBM PGM/PPM, GIF
     and PNG format.
 License: MIT + file LICENSE
+Encoding: UTF-8
 Imports: Rcpp (>= 1.0.0)
 LinkingTo: Rcpp
-RoxygenNote: 7.1.0
+RoxygenNote: 7.2.3
 Depends:
     R (>= 2.10)
 Suggests: 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -73,10 +73,10 @@ write_gif_core <- function(vec, dims, filename, convert_to_row_major = TRUE, fli
 #'    memory, but not for this use case.}
 #' }
 #'
-#' @param vec numeric 2d matrix or 3d array (with 3 planes)
-#' @param dims integer vector of length 2 i.e. \code{c(nrow, ncol)} for a matrix/grey image and of
+#' @param vec Numeric 2d matrix or 3d array (with 3 planes)
+#' @param dims Integer vector of length 2 i.e. \code{c(nrow, ncol)} for a matrix/grey image and of
 #'        length 3 i.e \code{c(nrow, ncol, 3)} for array/RGB output.
-#' @param filename output filename e.g. "example.ppm"
+#' @param filename Output filename e.g. "example.ppm"
 #' @param convert_to_row_major Convert to row-major order before output. R stores matrix
 #'        and array data in column-major order. In order to output row-major order (as
 #'        expected by PGM/PPM image format) data ordering must be converted. If this argument
@@ -86,21 +86,24 @@ write_gif_core <- function(vec, dims, filename, convert_to_row_major = TRUE, fli
 #'        Set flipy = TRUE for [0, 0] to represent the bottom-left corner.  This operation
 #'        is very fast and has negligible impact on overall write speed.
 #'        Default: flipy = FALSE.
-#' @param invert invert all the pixel brightness values - as if the image were
+#' @param invert Invert all the pixel brightness values - as if the image were
 #'        converted into a negative. Dark areas become bright and bright areas become dark.
 #'        Default: FALSE
 #' @param intensity_factor Multiplication factor applied to all values in image
 #'        (note: no checking is performed to ensure values remain in range [0, 1]).
 #'        If intensity_factor <= 0, then automatically determine (and apply) a multiplication factor
 #'        to set the maximum value to 1.0. Default: intensity_factor = 1.0
-#' @param pal integer matrix of size 256x3 with values in the range [0, 255]. Each
+#' @param pal Integer matrix of size 256x3 with values in the range [0, 255]. Each
 #'        row represents the r, g, b colour for a given grey index value. Only used
 #'        if \code{data} is a matrix
+#' @param with_alpha Include transparency in the png? Default: FALSE. If \code{TRUE}, also provide either \code{alpha_rgb} or \code{n_alpha} depending on the dimension of \code{data}
+#' @param alpha_rgb Integer vector of length 3 giving the RGB colour to make fully transparent. Only used if \code{data} is a 3d array
+#' @param n_alpha If \code{data} is a matrix and \code{pal} has been provided, \code{n_alpha} should be a positive integer and the first \code{n_alpha} colours in the palette will be fully transparent
 #'
 #'
 #'
-write_png_core <- function(vec, dims, filename, convert_to_row_major = TRUE, flipy = FALSE, invert = FALSE, intensity_factor = 1, pal = NULL) {
-    invisible(.Call(`_foist_write_png_core`, vec, dims, filename, convert_to_row_major, flipy, invert, intensity_factor, pal))
+write_png_core <- function(vec, dims, filename, convert_to_row_major = TRUE, flipy = FALSE, invert = FALSE, intensity_factor = 1, pal = NULL, with_alpha = FALSE, alpha_rgb = NULL, n_alpha = 0L) {
+    invisible(.Call(`_foist_write_png_core`, vec, dims, filename, convert_to_row_major, flipy, invert, intensity_factor, pal, with_alpha, alpha_rgb, n_alpha))
 }
 
 #' Write a vector of numeric data to a PNM file

--- a/R/write_png.R
+++ b/R/write_png.R
@@ -13,8 +13,8 @@
 #' \item{Matrix or array must be of type \code{numeric}}
 #' }
 #'
-#' @param data numeric 2d matrix or 3d array (with 3 planes)
-#' @param filename output filename e.g. "example.ppm"
+#' @param data Numeric 2d matrix or 3d array (with 3 planes)
+#' @param filename Output filename e.g. "example.ppm"
 #' @param convert_to_row_major Convert to row-major order before output. R stores matrix
 #'        and array data in column-major order. In order to output row-major order (as
 #'        expected by normal PNG output) data ordering must be converted. If this argument
@@ -24,25 +24,40 @@
 #'        Set flipy = TRUE for [0, 0] to represent the bottom-left corner.  This operation
 #'        is very fast and has negligible impact on overall write speed.
 #'        Default: flipy = FALSE.
-#' @param invert invert all the pixel brightness values - as if the image were
+#' @param invert Invert all the pixel brightness values - as if the image were
 #'        converted into a negative. Dark areas become bright and bright areas become dark.
 #'        Default: FALSE
 #' @param intensity_factor Multiplication factor applied to all values in image
 #'        (note: no checking is performed to ensure values remain in range [0, 1]).
 #'        If intensity_factor <= 0, then automatically determine (and apply) a multiplication factor
 #'        to set the maximum value to 1.0. Default: intensity_factor = 1.0
-#' @param pal integer matrix of size 256x3 with values in the range [0, 255]. Each
+#' @param pal Integer matrix of size 256x3 with values in the range [0, 255]. Each
 #'        row represents the r, g, b colour for a given grey index value. Only used
 #'        if \code{data} is a matrix
+#' @param alpha If \code{data} is a 3d array, \code{alpha} should be an integer vector of length 3 giving the RGB colour to make fully transparent. If \code{data} is a matrix and \code{pal} has been provided, \code{alpha} should be a positive integer and the first \code{alpha} colours in the palette will be fully transparent
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 write_png <- function(data, filename,
                       convert_to_row_major = TRUE,
                       flipy                = FALSE,
                       invert               = FALSE,
                       intensity_factor     = 1,
-                      pal                  = NULL) {
+                      pal                  = NULL,
+                      alpha) {
+    with_alpha <- FALSE
+    alpha_rgb <- c(0, 0, 0)
+    n_alpha <- 0
+    if (!missing(alpha) && length(alpha) > 0) {
+        if (length(dim(data)) == 3 && length(alpha) == 3) {
+            with_alpha <- TRUE
+            alpha_rgb <- alpha
+        }
+        if (!missing(pal) && length(dim(data)) == 2 && isTRUE(alpha > 0)) {
+            with_alpha <- TRUE
+            n_alpha <- alpha
+        }
+    }
     invisible(.Call(`_foist_write_png_core`, data, dim(data), filename,
-                    convert_to_row_major, flipy, invert, intensity_factor, pal))
+                    convert_to_row_major, flipy, invert, intensity_factor, pal, with_alpha, alpha_rgb, n_alpha))
 }
 
 

--- a/man/write_png.Rd
+++ b/man/write_png.Rd
@@ -11,13 +11,14 @@ write_png(
   flipy = FALSE,
   invert = FALSE,
   intensity_factor = 1,
-  pal = NULL
+  pal = NULL,
+  alpha
 )
 }
 \arguments{
-\item{data}{numeric 2d matrix or 3d array (with 3 planes)}
+\item{data}{Numeric 2d matrix or 3d array (with 3 planes)}
 
-\item{filename}{output filename e.g. "example.ppm"}
+\item{filename}{Output filename e.g. "example.ppm"}
 
 \item{convert_to_row_major}{Convert to row-major order before output. R stores matrix
 and array data in column-major order. In order to output row-major order (as
@@ -30,7 +31,7 @@ Set flipy = TRUE for [0, 0] to represent the bottom-left corner.  This operation
 is very fast and has negligible impact on overall write speed.
 Default: flipy = FALSE.}
 
-\item{invert}{invert all the pixel brightness values - as if the image were
+\item{invert}{Invert all the pixel brightness values - as if the image were
 converted into a negative. Dark areas become bright and bright areas become dark.
 Default: FALSE}
 
@@ -39,9 +40,11 @@ Default: FALSE}
 If intensity_factor <= 0, then automatically determine (and apply) a multiplication factor
 to set the maximum value to 1.0. Default: intensity_factor = 1.0}
 
-\item{pal}{integer matrix of size 256x3 with values in the range [0, 255]. Each
+\item{pal}{Integer matrix of size 256x3 with values in the range [0, 255]. Each
 row represents the r, g, b colour for a given grey index value. Only used
 if \code{data} is a matrix}
+
+\item{alpha}{If \code{data} is a 3d array, \code{alpha} should be an integer vector of length 3 giving the RGB colour to make fully transparent. If \code{data} is a matrix and \code{pal} has been provided, \code{alpha} should be a positive integer and the first \code{alpha} colours in the palette will be fully transparent}
 }
 \description{
 Write a numeric matrix or array to a PNG file

--- a/man/write_png_core.Rd
+++ b/man/write_png_core.Rd
@@ -12,16 +12,19 @@ write_png_core(
   flipy = FALSE,
   invert = FALSE,
   intensity_factor = 1,
-  pal = NULL
+  pal = NULL,
+  with_alpha = FALSE,
+  alpha_rgb = NULL,
+  n_alpha = 0L
 )
 }
 \arguments{
-\item{vec}{numeric 2d matrix or 3d array (with 3 planes)}
+\item{vec}{Numeric 2d matrix or 3d array (with 3 planes)}
 
-\item{dims}{integer vector of length 2 i.e. \code{c(nrow, ncol)} for a matrix/grey image and of
+\item{dims}{Integer vector of length 2 i.e. \code{c(nrow, ncol)} for a matrix/grey image and of
 length 3 i.e \code{c(nrow, ncol, 3)} for array/RGB output.}
 
-\item{filename}{output filename e.g. "example.ppm"}
+\item{filename}{Output filename e.g. "example.ppm"}
 
 \item{convert_to_row_major}{Convert to row-major order before output. R stores matrix
 and array data in column-major order. In order to output row-major order (as
@@ -34,7 +37,7 @@ Set flipy = TRUE for [0, 0] to represent the bottom-left corner.  This operation
 is very fast and has negligible impact on overall write speed.
 Default: flipy = FALSE.}
 
-\item{invert}{invert all the pixel brightness values - as if the image were
+\item{invert}{Invert all the pixel brightness values - as if the image were
 converted into a negative. Dark areas become bright and bright areas become dark.
 Default: FALSE}
 
@@ -43,9 +46,15 @@ Default: FALSE}
 If intensity_factor <= 0, then automatically determine (and apply) a multiplication factor
 to set the maximum value to 1.0. Default: intensity_factor = 1.0}
 
-\item{pal}{integer matrix of size 256x3 with values in the range [0, 255]. Each
+\item{pal}{Integer matrix of size 256x3 with values in the range [0, 255]. Each
 row represents the r, g, b colour for a given grey index value. Only used
 if \code{data} is a matrix}
+
+\item{with_alpha}{Include transparency in the png? Default: FALSE. If \code{TRUE}, also provide either \code{alpha_rgb} or \code{n_alpha} depending on the dimension of \code{data}}
+
+\item{alpha_rgb}{Integer vector of length 3 giving the RGB colour to make fully transparent. Only used if \code{data} is a 3d array}
+
+\item{n_alpha}{If \code{data} is a matrix and \code{pal} has been provided, \code{n_alpha} should be a positive integer and the first \code{n_alpha} colours in the palette will be fully transparent}
 }
 \description{
 Write a numeric matrix or array to a PNG file

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // write_gif_core
 void write_gif_core(const NumericVector vec, const IntegerVector dims, const std::string filename, const bool convert_to_row_major, const bool flipy, const bool invert, const double intensity_factor, Rcpp::IntegerMatrix pal);
 RcppExport SEXP _foist_write_gif_core(SEXP vecSEXP, SEXP dimsSEXP, SEXP filenameSEXP, SEXP convert_to_row_majorSEXP, SEXP flipySEXP, SEXP invertSEXP, SEXP intensity_factorSEXP, SEXP palSEXP) {
@@ -23,8 +28,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // write_png_core
-void write_png_core(const NumericVector vec, const IntegerVector dims, const std::string filename, const bool convert_to_row_major, const bool flipy, const bool invert, const double intensity_factor, Rcpp::Nullable<Rcpp::IntegerMatrix> pal);
-RcppExport SEXP _foist_write_png_core(SEXP vecSEXP, SEXP dimsSEXP, SEXP filenameSEXP, SEXP convert_to_row_majorSEXP, SEXP flipySEXP, SEXP invertSEXP, SEXP intensity_factorSEXP, SEXP palSEXP) {
+void write_png_core(const NumericVector vec, const IntegerVector dims, const std::string filename, const bool convert_to_row_major, const bool flipy, const bool invert, const double intensity_factor, Rcpp::Nullable<Rcpp::IntegerMatrix> pal, const bool with_alpha, Rcpp::Nullable<IntegerVector> alpha_rgb, const unsigned int n_alpha);
+RcppExport SEXP _foist_write_png_core(SEXP vecSEXP, SEXP dimsSEXP, SEXP filenameSEXP, SEXP convert_to_row_majorSEXP, SEXP flipySEXP, SEXP invertSEXP, SEXP intensity_factorSEXP, SEXP palSEXP, SEXP with_alphaSEXP, SEXP alpha_rgbSEXP, SEXP n_alphaSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const NumericVector >::type vec(vecSEXP);
@@ -35,7 +40,10 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const bool >::type invert(invertSEXP);
     Rcpp::traits::input_parameter< const double >::type intensity_factor(intensity_factorSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::IntegerMatrix> >::type pal(palSEXP);
-    write_png_core(vec, dims, filename, convert_to_row_major, flipy, invert, intensity_factor, pal);
+    Rcpp::traits::input_parameter< const bool >::type with_alpha(with_alphaSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<IntegerVector> >::type alpha_rgb(alpha_rgbSEXP);
+    Rcpp::traits::input_parameter< const unsigned int >::type n_alpha(n_alphaSEXP);
+    write_png_core(vec, dims, filename, convert_to_row_major, flipy, invert, intensity_factor, pal, with_alpha, alpha_rgb, n_alpha);
     return R_NilValue;
 END_RCPP
 }
@@ -59,7 +67,7 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_foist_write_gif_core", (DL_FUNC) &_foist_write_gif_core, 8},
-    {"_foist_write_png_core", (DL_FUNC) &_foist_write_png_core, 8},
+    {"_foist_write_png_core", (DL_FUNC) &_foist_write_png_core, 11},
     {"_foist_write_pnm_core", (DL_FUNC) &_foist_write_pnm_core, 8},
     {NULL, NULL, 0}
 };

--- a/src/write-png.cpp
+++ b/src/write-png.cpp
@@ -140,7 +140,7 @@ void write_PLTE(std::ofstream &outfile, Rcpp::IntegerMatrix pal) {
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Sanity check
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    if (pal.nrow() < 2 | pal.nrow() > 256 | pal.ncol() != 3) {
+    if (pal.nrow() < 2 || pal.nrow() > 256 || pal.ncol() != 3) {
       stop("\'pal\' must be a N x 3 IntegerMatrix with values in the range [0,255]");
     }
 

--- a/src/write-png.cpp
+++ b/src/write-png.cpp
@@ -183,7 +183,101 @@ void write_PLTE(std::ofstream &outfile, Rcpp::IntegerMatrix pal) {
     outfile.write(reinterpret_cast<const char *>(&crc32), sizeof(crc32));
 }
 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// - Write out a tRNS (transparency) chunk for indexed RGB file
+// - Reference: http://www.libpng.org/pub/png/spec/1.2/PNG-Chunks.html
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+void write_tRNS_n(std::ofstream &outfile, unsigned int n, Rcpp::IntegerMatrix pal) {
 
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Sanity check
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    if (n < 1 || int(n) > pal.nrow()) {
+      stop("number of transparent colours must be at least 1 and no more than the number of palette entries");
+    }
+
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // tRNS header
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    unsigned char tRNS[4] = {
+      116, 82, 78, 83  // "tRNS"
+    };
+
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Write tRNS header to output
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    uint32_t data_length = n;
+    data_length = bswap32(data_length);
+    outfile.write(reinterpret_cast<const char *>(&data_length), sizeof(data_length));
+
+    uint32_t crc32 = 0;
+    outfile.write((const char *)&tRNS[0], 4);
+    crc32 = crc32_16bytes(&tRNS[0], 4, crc32);
+
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // One byte alpha value (zero) for each transparent colour
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    for (int i = 0; i < int(n); ++i) {
+      outfile.write(0, 1);
+    }
+    crc32 = crc32_16bytes(0, n, crc32);
+
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Write tRNS CRC32 to output
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    crc32 = bswap32(crc32);
+    outfile.write(reinterpret_cast<const char *>(&crc32), sizeof(crc32));
+}
+
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// - Write out a tRNS (transparency) chunk for RGB file
+// - Reference: http://www.libpng.org/pub/png/spec/1.2/PNG-Chunks.html
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+void write_tRNS_rgb(std::ofstream &outfile, const IntegerVector alpha_rgb) {
+
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Sanity check
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    if (alpha_rgb.length() != 3) {
+      stop("alpha rgb must be of length 3");
+    }
+
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // tRNS header
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    unsigned char tRNS[4] = {
+      116, 82, 78, 83  // "tRNS"
+    };
+
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Write tRNS header to output
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    uint32_t data_length = 6;
+    data_length = bswap32(data_length);
+    outfile.write(reinterpret_cast<const char *>(&data_length), sizeof(data_length));
+
+    uint32_t crc32 = 0;
+    outfile.write((const char *)&tRNS[0], 4);
+    crc32 = crc32_16bytes(&tRNS[0], 4, crc32);
+
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Write the RGB of the transparent colour as three 2-byte values
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    uint16_t i16rgb[3];
+    uint16_t *pi16rgb = &i16rgb[0];
+    *pi16rgb++ = (uint16_t)alpha_rgb[0];
+    *pi16rgb++ = (uint16_t)alpha_rgb[1];
+    *pi16rgb++ = (uint16_t)alpha_rgb[2];
+    outfile.write((const char *)&i16rgb[0], 6);
+    crc32 = crc32_16bytes(&i16rgb[0], 6, crc32);
+
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Write tRNS CRC32 to output
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    crc32 = bswap32(crc32);
+    outfile.write(reinterpret_cast<const char *>(&crc32), sizeof(crc32));
+}
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //
@@ -665,10 +759,10 @@ void write_png_RGB_data(std::ofstream &outfile,
 //'    memory, but not for this use case.}
 //' }
 //'
-//' @param vec numeric 2d matrix or 3d array (with 3 planes)
-//' @param dims integer vector of length 2 i.e. \code{c(nrow, ncol)} for a matrix/grey image and of
+//' @param vec Numeric 2d matrix or 3d array (with 3 planes)
+//' @param dims Integer vector of length 2 i.e. \code{c(nrow, ncol)} for a matrix/grey image and of
 //'        length 3 i.e \code{c(nrow, ncol, 3)} for array/RGB output.
-//' @param filename output filename e.g. "example.ppm"
+//' @param filename Output filename e.g. "example.ppm"
 //' @param convert_to_row_major Convert to row-major order before output. R stores matrix
 //'        and array data in column-major order. In order to output row-major order (as
 //'        expected by PGM/PPM image format) data ordering must be converted. If this argument
@@ -678,16 +772,19 @@ void write_png_RGB_data(std::ofstream &outfile,
 //'        Set flipy = TRUE for [0, 0] to represent the bottom-left corner.  This operation
 //'        is very fast and has negligible impact on overall write speed.
 //'        Default: flipy = FALSE.
-//' @param invert invert all the pixel brightness values - as if the image were
+//' @param invert Invert all the pixel brightness values - as if the image were
 //'        converted into a negative. Dark areas become bright and bright areas become dark.
 //'        Default: FALSE
 //' @param intensity_factor Multiplication factor applied to all values in image
 //'        (note: no checking is performed to ensure values remain in range [0, 1]).
 //'        If intensity_factor <= 0, then automatically determine (and apply) a multiplication factor
 //'        to set the maximum value to 1.0. Default: intensity_factor = 1.0
-//' @param pal integer matrix of size 256x3 with values in the range [0, 255]. Each
+//' @param pal Integer matrix of size 256x3 with values in the range [0, 255]. Each
 //'        row represents the r, g, b colour for a given grey index value. Only used
 //'        if \code{data} is a matrix
+//' @param with_alpha Include transparency in the png? Default: FALSE. If \code{TRUE}, also provide either \code{alpha_rgb} or \code{n_alpha} depending on the dimension of \code{data}
+//' @param alpha_rgb Integer vector of length 3 giving the RGB colour to make fully transparent. Only used if \code{data} is a 3d array
+//' @param n_alpha If \code{data} is a matrix and \code{pal} has been provided, \code{n_alpha} should be a positive integer and the first \code{n_alpha} colours in the palette will be fully transparent
 //'
 //'
 //'
@@ -699,7 +796,10 @@ void write_png_core(const NumericVector vec,
                     const bool flipy                = false,
                     const bool invert               = false,
                     const double intensity_factor   = 1,
-                    Rcpp::Nullable<Rcpp::IntegerMatrix> pal = R_NilValue) {
+                    Rcpp::Nullable<Rcpp::IntegerMatrix> pal = R_NilValue,
+                    const bool with_alpha           = false,
+                    Rcpp::Nullable<IntegerVector> alpha_rgb = R_NilValue,
+                    const unsigned int n_alpha      = 0) {
 
 
   unsigned int nrow = dims[0];
@@ -769,6 +869,16 @@ void write_png_core(const NumericVector vec,
     Rcpp::IntegerMatrix pal_(pal);
     write_PLTE(outfile, pal_);
     scale_factor = pal_.nrow() - 1;
+    if (with_alpha) {
+      // for Indexed Palette RGB, the first n colours can be transparent
+      write_tRNS_n(outfile, n_alpha, pal_);
+    }
+  }
+
+  if (colour_type == 2 && with_alpha) {
+    // for colour_type 2 (RGB), we can nominate a single RGB colour to be transparent
+    IntegerVector trgb_(alpha_rgb);
+    write_tRNS_rgb(outfile, trgb_);
   }
 
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/write-png.cpp
+++ b/src/write-png.cpp
@@ -25,7 +25,10 @@ static inline uint32_t bswap32(uint32_t x) {
          (x << 24);
 #endif
 }
-
+// And same for 16bit unsigned int
+static inline uint16_t bswap16(uint16_t x) {
+    return (x << 8) | ((x >> 8) & 0xFF);
+}
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //
@@ -268,9 +271,9 @@ void write_tRNS_rgb(std::ofstream &outfile, const IntegerVector alpha_rgb) {
 
     uint16_t i16rgb[3];
     uint16_t *pi16rgb = &i16rgb[0];
-    *pi16rgb++ = (uint16_t)alpha_rgb[0];
-    *pi16rgb++ = (uint16_t)alpha_rgb[1];
-    *pi16rgb++ = (uint16_t)alpha_rgb[2];
+    *pi16rgb++ = bswap16((uint16_t)alpha_rgb[0]);
+    *pi16rgb++ = bswap16((uint16_t)alpha_rgb[1]);
+    *pi16rgb++ = bswap16((uint16_t)alpha_rgb[2]);
     outfile.write((const char *)&i16rgb[0], 6);
     crc32 = crc32_16bytes(&i16rgb[0], 6, crc32);
 

--- a/src/write-png.cpp
+++ b/src/write-png.cpp
@@ -216,11 +216,13 @@ void write_tRNS_n(std::ofstream &outfile, unsigned int n, Rcpp::IntegerMatrix pa
 
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // One byte alpha value (zero) for each transparent colour
+    // Typically this will only be n=1
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    unsigned char z[1] = { 0 };
     for (int i = 0; i < int(n); ++i) {
-      outfile.write(0, 1);
+      outfile.write((const char *)&z[0], 1);
+      crc32 = crc32_16bytes(&z[0], n, crc32);
     }
-    crc32 = crc32_16bytes(0, n, crc32);
 
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Write tRNS CRC32 to output


### PR DESCRIPTION
Adds support for "cheap alpha" transparency in PNGs - i.e. one or more colours can be designated as fully transparent: http://www.libpng.org/pub/png/book/chapter08.html#png.ch08.div.5.2

- In an RGB image (i.e. `write_png(data, ...)` where `data` is a 3d array), one colour can be designated as transparent by providing its RGB value.
- In an RGB-indexed image (i.e. `data` is a matrix and `pal` has been provided) the PNG spec allows for the first `n` colours in the palette to be made fully transparent. Typically this would be just one colour.

It only adds a few tens of bytes per file, and my brief testing showed no significant performance hit. I did not include any formal unit testing because I could not get `writePNG` or `magick::write_image` to produce a PNG with this type of transparency (magick does full RGBA by default, couldn't figure out how to coerce it to produce png8).

(My C++ skills are not what you'd call polished, feel free to change the implementation!)